### PR TITLE
Fix bug where streaming throws an exception after long use

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -313,11 +313,12 @@ class Stream(object):
         while self.running and not resp.raw.closed:
             length = 0
             while not resp.raw.closed:
-                line = buf.read_line().strip()
-                if not line:
+                line = buf.read_line()
+                stripped_line = line.strip() if line else line # line is sometimes None so we need to check here
+                if not stripped_line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
-                elif line.strip().isdigit():
-                    length = int(line)
+                elif stripped_line.isdigit():
+                    length = int(stripped_line)
                     break
                 else:
                     raise TweepError('Expecting length, unexpected value found')


### PR DESCRIPTION
When we go to read the next line this method sometimes is return None (dead socket?).
Guard against this with a check first before trying to strip the result.

Fixes #1026